### PR TITLE
ProductBacklog 등록 및 조회 API에 대한 priority 필드 추가

### DIFF
--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiGetAllProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiGetAllProductBacklog.kt
@@ -13,6 +13,7 @@ object ApiGetAllProductBacklog {
         val productBacklogRowid: Long,
         val title: String,
         val description: String,
+        val priority: ProductBacklogPriority,
         val regDate: LocalDateTime
     )
 }

--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiGetAllProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiGetAllProductBacklog.kt
@@ -1,5 +1,6 @@
 package com.project.scrumbleserver.api.productBacklog
 
+import com.project.scrumbleserver.domain.productBacklog.ProductBacklogPriority
 import java.time.LocalDateTime
 
 object ApiGetAllProductBacklog {

--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
@@ -6,7 +6,8 @@ object ApiPostProductBacklog {
     data class Request(
         val projectRowid: Long,
         val title: String,
-        val description: String
+        val description: String,
+        val priority: ProductBacklogPriority,
     )
 
     data class Response(

--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
@@ -1,5 +1,6 @@
 package com.project.scrumbleserver.api.productBacklog
 
+import com.project.scrumbleserver.domain.productBacklog.ProductBacklogPriority
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size

--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ProductBacklogPriority.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ProductBacklogPriority.kt
@@ -1,0 +1,5 @@
+package com.project.scrumbleserver.api.productBacklog
+
+enum class ProductBacklogPriority {
+    HIGH, MEDIUM, LOW, UNDEFINED;
+}

--- a/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklog.kt
@@ -1,6 +1,5 @@
 package com.project.scrumbleserver.domain.productBacklog
 
-import com.project.scrumbleserver.domain.productBacklog.ProductBacklogPriority
 import com.project.scrumbleserver.domain.BaseEntity
 import com.project.scrumbleserver.domain.project.Project
 import jakarta.persistence.Column
@@ -13,7 +12,6 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.Table
 
 @Entity(name = "product_backlog")
 class ProductBacklog(
@@ -26,13 +24,13 @@ class ProductBacklog(
     @JoinColumn(name = "project_rowid", nullable = false)
     val project: Project,
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 30)
     var title: String,
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 300)
     var description: String = "",
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    var priority: ProductBacklogPriority = ProductBacklogPriority.UNDEFINED
+    var priority: ProductBacklogPriority = ProductBacklogPriority.NONE
 ) : BaseEntity()

--- a/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklog.kt
@@ -1,6 +1,6 @@
 package com.project.scrumbleserver.domain.productBacklog
 
-import com.project.scrumbleserver.api.productBacklog.ProductBacklogPriority
+import com.project.scrumbleserver.domain.productBacklog.ProductBacklogPriority
 import com.project.scrumbleserver.domain.BaseEntity
 import com.project.scrumbleserver.domain.project.Project
 import jakarta.persistence.Column
@@ -35,8 +35,4 @@ class ProductBacklog(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var priority: ProductBacklogPriority = ProductBacklogPriority.UNDEFINED
-
-    // 시작 시간, 예상(완료) 시간인데, 아직은 주석 처리
-//    var startDate: LocalDateTime,
-//    var endDate: LocalDateTime,
 ) : BaseEntity()

--- a/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklog.kt
@@ -1,9 +1,12 @@
 package com.project.scrumbleserver.domain.productBacklog
 
+import com.project.scrumbleserver.api.productBacklog.ProductBacklogPriority
 import com.project.scrumbleserver.domain.BaseEntity
 import com.project.scrumbleserver.domain.project.Project
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -23,9 +26,15 @@ class ProductBacklog(
     @JoinColumn(name = "project_rowid", nullable = false)
     val project: Project,
 
+    @Column(nullable = false)
     var title: String,
 
-    var description: String,
+    @Column(nullable = false)
+    var description: String = "",
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var priority: ProductBacklogPriority = ProductBacklogPriority.UNDEFINED
 
     // 시작 시간, 예상(완료) 시간인데, 아직은 주석 처리
 //    var startDate: LocalDateTime,

--- a/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklogPriority.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklogPriority.kt
@@ -1,5 +1,5 @@
 package com.project.scrumbleserver.domain.productBacklog
 
 enum class ProductBacklogPriority {
-    HIGH, MEDIUM, LOW, UNDEFINED;
+    HIGH, MEDIUM, LOW, NONE;
 }

--- a/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklogPriority.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklogPriority.kt
@@ -1,4 +1,4 @@
-package com.project.scrumbleserver.api.productBacklog
+package com.project.scrumbleserver.domain.productBacklog
 
 enum class ProductBacklogPriority {
     HIGH, MEDIUM, LOW, UNDEFINED;

--- a/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
@@ -22,7 +22,8 @@ class ProductBacklogService(
             ProductBacklog(
                 project = project,
                 title = request.title,
-                description = request.description
+                description = request.description,
+                priority = request.priority,
             )
         )
 

--- a/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
@@ -38,6 +38,7 @@ class ProductBacklogService(
                 productBacklogRowid = it.rowid,
                 title = it.title,
                 description = it.description,
+                priority = it.priority,
                 regDate = it.regDate
             )
         }


### PR DESCRIPTION
## 반영 사항

> 관련 이슈 : #18 

- ProductBacklog 등록 요청 시 `priority` 필드를 받도록 추가
- ProductBacklog 목록 응답에 대해 `priority` 필드 추가