### PR TITLE
ProductBacklog 등록 시 validation 추가

### DIFF
--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
@@ -4,9 +4,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
-object ApiPostProductBacklog {
-    const val PATH = "/api/v1/product-backlog"
-}
+const val API_POST_PRODUCT_BACKLOG_PATH = "/api/v1/product-backlog"
 
 data class ApiPostProductBacklogRequest(
     @field:NotNull(message = "projectRowid는 필수입니다.")

--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
@@ -1,16 +1,28 @@
 package com.project.scrumbleserver.api.productBacklog
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
 object ApiPostProductBacklog {
     const val PATH = "/api/v1/product-backlog"
-
-    data class Request(
-        val projectRowid: Long,
-        val title: String,
-        val description: String,
-        val priority: ProductBacklogPriority,
-    )
-
-    data class Response(
-        val productBacklogRowid: Long
-    )
 }
+
+data class ApiPostProductBacklogRequest(
+    @field:NotNull(message = "projectRowid는 필수입니다.")
+    val projectRowid: Long,
+
+    @field:NotBlank(message = "title은 필수입니다.")
+    @field:Size(max = 30, message = "title은 100자 이하로 입력해야 합니다.")
+    val title: String,
+
+    @field:Size(max = 350, message = "description은 350자 이하로 입력해야 합니다.")
+    val description: String,
+
+    @field:NotNull(message = "priority는 필수입니다.")
+    val priority: ProductBacklogPriority
+)
+
+data class ApiPostProductBacklogResponse(
+    val productBacklogRowid: Long
+)

--- a/src/main/kotlin/com/project/scrumbleserver/controller/handler/ApiControllerAdvice.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/handler/ApiControllerAdvice.kt
@@ -1,4 +1,4 @@
-package com.project.scrumbleserver.controller
+package com.project.scrumbleserver.controller.handler
 
 import com.project.scrumbleserver.global.api.ApiResponse
 import com.project.scrumbleserver.global.excception.BusinessException
@@ -6,6 +6,7 @@ import com.project.scrumbleserver.global.excception.ServerException
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -20,22 +21,26 @@ class ApiControllerAdvice {
 
     @ExceptionHandler(BusinessException::class)
     fun exceptionHandler(e: BusinessException): ResponseEntity<ApiResponse<ErrorResponse>> {
-        val errorResponse = ApiResponse.of(ErrorResponse(e.message), e.status)
+        val errorResponse = ApiResponse.Companion.of(ErrorResponse(e.message), e.status)
         logger.warn(e.message)
         return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, e.status)
     }
 
     @ExceptionHandler(ServerException::class)
     fun exceptionHandler(e: ServerException): ResponseEntity<ApiResponse<ErrorResponse>> {
-        val errorResponse = ApiResponse.of(ErrorResponse(e.message), HttpStatus.INTERNAL_SERVER_ERROR)
+        val errorResponse = ApiResponse.Companion.of(ErrorResponse(e.message), HttpStatus.INTERNAL_SERVER_ERROR)
         logger.error(e.stackTraceToString())
         return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR)
     }
 
-    @ExceptionHandler(Exception::class)
-    fun exceptionHandler(e: Exception): ResponseEntity<ApiResponse<ErrorResponse>> {
-        val errorResponse = ApiResponse.of(ErrorResponse(e.message ?: "error"), HttpStatus.INTERNAL_SERVER_ERROR)
-        logger.error(e.stackTraceToString())
-        return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationEx(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<*>> {
+        val errorMessages = ex.bindingResult.fieldErrors.associate {
+            it.field to (it.defaultMessage ?: "잘못된 값입니다.")
+        }
+
+        return ResponseEntity
+            .badRequest()
+            .body(ApiResponse.of(errorMessages, HttpStatus.BAD_REQUEST))
     }
 }

--- a/src/main/kotlin/com/project/scrumbleserver/controller/handler/ApiControllerAdvice.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/handler/ApiControllerAdvice.kt
@@ -21,14 +21,14 @@ class ApiControllerAdvice {
 
     @ExceptionHandler(BusinessException::class)
     fun exceptionHandler(e: BusinessException): ResponseEntity<ApiResponse<ErrorResponse>> {
-        val errorResponse = ApiResponse.Companion.of(ErrorResponse(e.message), e.status)
+        val errorResponse = ApiResponse.of(ErrorResponse(e.message), e.status)
         logger.warn(e.message)
         return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, e.status)
     }
 
     @ExceptionHandler(ServerException::class)
     fun exceptionHandler(e: ServerException): ResponseEntity<ApiResponse<ErrorResponse>> {
-        val errorResponse = ApiResponse.Companion.of(ErrorResponse(e.message), HttpStatus.INTERNAL_SERVER_ERROR)
+        val errorResponse = ApiResponse.of(ErrorResponse(e.message), HttpStatus.INTERNAL_SERVER_ERROR)
         logger.error(e.stackTraceToString())
         return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR)
     }

--- a/src/main/kotlin/com/project/scrumbleserver/controller/productBacklog/ProductBacklogController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/productBacklog/ProductBacklogController.kt
@@ -2,10 +2,13 @@ package com.project.scrumbleserver.controller.productBacklog
 
 import com.project.scrumbleserver.api.productBacklog.ApiGetAllProductBacklog
 import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklog
+import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklogRequest
+import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklogResponse
 import com.project.scrumbleserver.global.api.ApiResponse
 import com.project.scrumbleserver.service.productBacklog.ProductBacklogService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -23,11 +26,11 @@ class ProductBacklogController(
         description = "요청 정보를 기반으로 새 프로덕트 백로그를 생성합니다."
     )
     fun add(
-        @RequestBody
-        request: ApiPostProductBacklog.Request
-    ): ApiResponse<ApiPostProductBacklog.Response> {
+        @RequestBody @Valid
+        request: ApiPostProductBacklogRequest
+    ): ApiResponse<ApiPostProductBacklogResponse> {
         val productBacklogRowid = productBacklogService.insert(request)
-        val response = ApiPostProductBacklog.Response(productBacklogRowid)
+        val response = ApiPostProductBacklogResponse(productBacklogRowid)
         return ApiResponse.of(response)
     }
 

--- a/src/main/kotlin/com/project/scrumbleserver/controller/productBacklog/ProductBacklogController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/productBacklog/ProductBacklogController.kt
@@ -1,7 +1,7 @@
 package com.project.scrumbleserver.controller.productBacklog
 
+import com.project.scrumbleserver.api.productBacklog.API_POST_PRODUCT_BACKLOG_PATH
 import com.project.scrumbleserver.api.productBacklog.ApiGetAllProductBacklog
-import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklog
 import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklogRequest
 import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklogResponse
 import com.project.scrumbleserver.global.api.ApiResponse
@@ -20,7 +20,7 @@ class ProductBacklogController(
     private val productBacklogService: ProductBacklogService,
 ) {
 
-    @PostMapping(ApiPostProductBacklog.PATH)
+    @PostMapping(API_POST_PRODUCT_BACKLOG_PATH)
     @Operation(
         summary = "프로덕트 백로그 등록",
         description = "요청 정보를 기반으로 새 프로덕트 백로그를 생성합니다."

--- a/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
@@ -2,6 +2,7 @@ package com.project.scrumbleserver.service.productBacklog
 
 import com.project.scrumbleserver.api.productBacklog.ApiGetAllProductBacklog
 import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklog
+import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklogRequest
 import com.project.scrumbleserver.domain.productBacklog.ProductBacklog
 import com.project.scrumbleserver.global.excception.BusinessException
 import com.project.scrumbleserver.repository.productBacklog.ProductBacklogRepository
@@ -14,7 +15,7 @@ class ProductBacklogService(
     private val productBacklogRepository: ProductBacklogRepository,
     private val projectRepository: ProjectRepository
 ) {
-    fun insert(request: ApiPostProductBacklog.Request): Long {
+    fun insert(request: ApiPostProductBacklogRequest): Long {
         val project = projectRepository.findByIdOrNull(request.projectRowid)
             ?: throw BusinessException("프로젝트를 찾을 수 없습니다.")
 


### PR DESCRIPTION
## 변경 사항

![image](https://github.com/user-attachments/assets/52b6d83a-3cf1-409c-973a-d871dbe0cae1)

- swagger에 Request 필드가 제대로 보여지지 않는 버그 수정
- `ApiProductBacklog` object 내부 Request, Response를 상위 클래스로 분리
   - `object`는 `static class`로 컴파일 되는데, 내부 클래스로 설정할 경우, springdoc-openapi에서 리플렉션을 못하는 이슈가 있어서 분리했습니다~!
   - 참고 : [Springdoc Issue #32](https://github.com/springdoc/springdoc.github.io/issues/32)