### PR TITLE
ProductBacklog가 등록될 때, Tag를 추가할 수 있도록 수정

### DIFF
--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiGetAllProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiGetAllProductBacklog.kt
@@ -12,11 +12,17 @@ data class ApiGetAllProductBacklogRequest(
 data class ApiGetAllProductBacklogResponse(
     val productBacklogs: List<ProductBacklog>
 ) {
+    data class ProductBacklogTag(
+        val productBacklogTagRowid: Long,
+        val title: String,
+        val color: String
+    )
     data class ProductBacklog(
         val productBacklogRowid: Long,
         val title: String,
         val description: String,
         val priority: ProductBacklogPriority,
+        val tags: List<ProductBacklogTag>,
         val regDate: LocalDateTime
     )
 }

--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiPostProductBacklog.kt
@@ -19,7 +19,10 @@ data class ApiPostProductBacklogRequest(
     val description: String,
 
     @field:NotNull(message = "priority는 필수입니다.")
-    val priority: ProductBacklogPriority
+    val priority: ProductBacklogPriority,
+
+    @field:Size(max = 10, message = "최대 10개의 태그만 지정할 수 있습니다.")
+    val tags: Set<Long>,
 )
 
 data class ApiPostProductBacklogResponse(

--- a/src/main/kotlin/com/project/scrumbleserver/api/tag/ApiGetAllTag.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/tag/ApiGetAllTag.kt
@@ -1,0 +1,21 @@
+package com.project.scrumbleserver.api.tag
+
+import java.time.LocalDateTime
+
+const val API_GET_ALL_TAG_PATH = "/api/v1/tags"
+
+data class ApiGetAllTagRequest(
+    val projectRowid: Long
+)
+
+data class ApiGetAllTagResponse(
+    val tags: List<Tag>
+) {
+    data class Tag(
+        val tagRowid: Long,
+        val projectRowid: Long,
+        val title: String,
+        val color: String,
+        val regDate: LocalDateTime
+    )
+}

--- a/src/main/kotlin/com/project/scrumbleserver/controller/tag/TagController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/tag/TagController.kt
@@ -1,0 +1,32 @@
+package com.project.scrumbleserver.controller.tag
+
+import com.project.scrumbleserver.api.tag.API_GET_ALL_TAG_PATH
+import com.project.scrumbleserver.api.tag.ApiGetAllTagRequest
+import com.project.scrumbleserver.api.tag.ApiGetAllTagResponse
+import com.project.scrumbleserver.global.api.ApiResponse
+import com.project.scrumbleserver.service.tag.TagService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@Tag(name = "Tag", description = "프로젝트 태그 관련 API")
+class TagController(
+    private val tagService: TagService,
+) {
+    @GetMapping(API_GET_ALL_TAG_PATH)
+    @Operation(
+        summary = "프로젝트의 전체 태그 조회",
+        description = "프로젝트의 모든 태그 목록을 반환합니다."
+    )
+    fun findAll(
+        @RequestBody
+        request: ApiGetAllTagRequest
+    ): ApiResponse<List<ApiGetAllTagResponse>> {
+        val tags = tagService.findAllByProjectRowid(request.projectRowid)
+
+        return ApiResponse.of(tags)
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/productBacklog/ProductBacklog.kt
@@ -1,7 +1,9 @@
 package com.project.scrumbleserver.domain.productBacklog
 
 import com.project.scrumbleserver.domain.BaseEntity
+import com.project.scrumbleserver.domain.productBacklogTag.ProductBacklogTag
 import com.project.scrumbleserver.domain.project.Project
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -12,6 +14,7 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 
 @Entity(name = "product_backlog")
 class ProductBacklog(
@@ -32,5 +35,8 @@ class ProductBacklog(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    var priority: ProductBacklogPriority = ProductBacklogPriority.NONE
+    var priority: ProductBacklogPriority = ProductBacklogPriority.NONE,
+
+    @OneToMany(mappedBy = "productBacklog", orphanRemoval = true, cascade = [CascadeType.ALL])
+    val tags: MutableList<ProductBacklogTag> = mutableListOf(),
 ) : BaseEntity()

--- a/src/main/kotlin/com/project/scrumbleserver/domain/productBacklogTag/ProductBacklogTag.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/productBacklogTag/ProductBacklogTag.kt
@@ -1,0 +1,33 @@
+package com.project.scrumbleserver.domain.productBacklogTag
+
+import com.project.scrumbleserver.domain.BaseEntity
+import com.project.scrumbleserver.domain.productBacklog.ProductBacklog
+import com.project.scrumbleserver.domain.productBacklog.ProductBacklogPriority
+import com.project.scrumbleserver.domain.project.Project
+import com.project.scrumbleserver.domain.tag.Tag
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class ProductBacklogTag(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_backlog_tag_rowid")
+    var rowid: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_backlog_rowid", nullable = false)
+    val productBacklog: ProductBacklog,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_rowid", nullable = false)
+    val tag: Tag,
+) : BaseEntity()

--- a/src/main/kotlin/com/project/scrumbleserver/domain/productBacklogTag/ProductBacklogTag.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/productBacklogTag/ProductBacklogTag.kt
@@ -15,8 +15,10 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
 
 @Entity
+@Table(name = "product_backlog_tag")
 class ProductBacklogTag(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/project/scrumbleserver/domain/tag/BasicTag.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/tag/BasicTag.kt
@@ -1,0 +1,39 @@
+package com.project.scrumbleserver.domain.tag
+
+enum class BasicTag(
+    val title: String,
+    val color: String,
+) {
+    FEATURE(
+        title = "Feature",
+        color = "#0E8A16"
+    ),
+    BUG(
+        title = "Bug",
+        color = "#D73A4A"
+    ),
+    IMPROVEMENT(
+        title = "Improvement",
+        color = "#1D76DB"
+    ),
+    REFACTOR(
+        title = "Refactor",
+        color = "#6F42C1"
+    ),
+    DOCS(
+        title = "Docs",
+        color = "#CFD3D7"
+    ),
+    DESIGN(
+        title = "Design",
+        color = "#FF69B4"
+    ),
+    TEST(
+        title = "Test",
+        color = "#A2EEEF"
+    ),
+    CHORE(
+        title = "Chore",
+        color = "#8B949E"
+    ),
+}

--- a/src/main/kotlin/com/project/scrumbleserver/domain/tag/Tag.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/tag/Tag.kt
@@ -1,0 +1,33 @@
+package com.project.scrumbleserver.domain.tag
+
+import com.project.scrumbleserver.domain.BaseEntity
+import com.project.scrumbleserver.domain.productBacklog.ProductBacklogPriority
+import com.project.scrumbleserver.domain.project.Project
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class Tag(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tag_rowid")
+    var rowid: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_rowid", nullable = false)
+    val project: Project,
+
+    @Column(nullable = false, length = 100)
+    var title: String,
+
+    @Column(nullable = false, length = 10)
+    var color: String = ""
+) : BaseEntity()

--- a/src/main/kotlin/com/project/scrumbleserver/repository/productBacklogTag/ProductBacklogTagRepository.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/repository/productBacklogTag/ProductBacklogTagRepository.kt
@@ -1,0 +1,11 @@
+package com.project.scrumbleserver.repository.productBacklogTag
+
+import com.project.scrumbleserver.domain.productBacklog.ProductBacklog
+import com.project.scrumbleserver.domain.productBacklogTag.ProductBacklogTag
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProductBacklogTagRepository : JpaRepository<ProductBacklogTag, Long> {
+    fun findAllByProductBacklog(productBacklog: ProductBacklog): List<ProductBacklogTag>
+}

--- a/src/main/kotlin/com/project/scrumbleserver/repository/tag/TagRepository.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/repository/tag/TagRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface TagRepository : JpaRepository<Tag, Long> {
+    fun findAllByProject(projectId: Project): List<Tag>
 }

--- a/src/main/kotlin/com/project/scrumbleserver/repository/tag/TagRepository.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/repository/tag/TagRepository.kt
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface TagRepository : JpaRepository<Tag, Long> {
+    fun findAllByRowidIsIn(tagRowids: Set<Long>): List<Tag>
     fun findAllByProject(projectId: Project): List<Tag>
 }

--- a/src/main/kotlin/com/project/scrumbleserver/repository/tag/TagRepository.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/repository/tag/TagRepository.kt
@@ -1,0 +1,10 @@
+package com.project.scrumbleserver.repository.tag
+
+import com.project.scrumbleserver.domain.project.Project
+import com.project.scrumbleserver.domain.tag.Tag
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TagRepository : JpaRepository<Tag, Long> {
+}

--- a/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
@@ -85,6 +85,13 @@ class ProductBacklogService(
                         title = it.title,
                         description = it.description,
                         priority = it.priority,
+                        tags = it.tags.map { tag ->
+                            ApiGetAllProductBacklogResponse.ProductBacklogTag(
+                                tag.rowid,
+                                tag.tag.title,
+                                tag.tag.color
+                            )
+                        },
                         regDate = it.regDate
                     )
                 )

--- a/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
@@ -3,17 +3,25 @@ package com.project.scrumbleserver.service.productBacklog
 import com.project.scrumbleserver.api.productBacklog.ApiGetAllProductBacklogResponse
 import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklogRequest
 import com.project.scrumbleserver.domain.productBacklog.ProductBacklog
+import com.project.scrumbleserver.domain.productBacklogTag.ProductBacklogTag
+import com.project.scrumbleserver.domain.tag.Tag
 import com.project.scrumbleserver.global.excception.BusinessException
 import com.project.scrumbleserver.repository.productBacklog.ProductBacklogRepository
+import com.project.scrumbleserver.repository.productBacklogTag.ProductBacklogTagRepository
 import com.project.scrumbleserver.repository.project.ProjectRepository
+import com.project.scrumbleserver.repository.tag.TagRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ProductBacklogService(
     private val productBacklogRepository: ProductBacklogRepository,
+    private val productBacklogTagRepository: ProductBacklogTagRepository,
     private val projectRepository: ProjectRepository,
+    private val tagRepository: TagRepository,
 ) {
+    @Transactional
     fun insert(request: ApiPostProductBacklogRequest): Long {
         val project = projectRepository.findByIdOrNull(request.projectRowid)
             ?: throw BusinessException("프로젝트를 찾을 수 없습니다.")
@@ -27,9 +35,45 @@ class ProductBacklogService(
             )
         )
 
+        saveProductBacklogTags(project.rowid, productBacklog, request.tags)
+
         return productBacklog.rowid
     }
 
+    private fun saveProductBacklogTags(
+        projectRowid: Long,
+        productBacklog: ProductBacklog,
+        requestedTagIds: Set<Long>
+    ) {
+        val tags = tagRepository.findAllByRowidIsIn(requestedTagIds)
+
+        validateTags(projectRowid, tags, requestedTagIds)
+
+        val tagMappings = tags.map {
+            ProductBacklogTag(
+                productBacklog = productBacklog,
+                tag = it
+            )
+        }
+
+        productBacklogTagRepository.saveAll(tagMappings)
+    }
+
+    private fun validateTags(
+        projectRowid: Long,
+        tags: List<Tag>,
+        requestedTagIds: Set<Long>
+    ) {
+        if (tags.size != requestedTagIds.size) {
+            throw BusinessException("존재하지 않는 태그가 포함되어 있습니다.")
+        }
+
+        if (tags.any { it.project.rowid != projectRowid }) {
+            throw BusinessException("해당 프로젝트에 속하지 않은 태그가 포함되어 있습니다.")
+        }
+    }
+
+    @Transactional(readOnly = true)
     fun findAll(projectRowid: Long): List<ApiGetAllProductBacklogResponse> {
         val productBacklogList = productBacklogRepository.findAllByProjectRowid(projectRowid)
 

--- a/src/main/kotlin/com/project/scrumbleserver/service/project/ProjectService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/project/ProjectService.kt
@@ -5,22 +5,26 @@ import com.project.scrumbleserver.api.project.ApiPostProjectRequest
 import com.project.scrumbleserver.api.project.ApiPostProjectResponse
 import com.project.scrumbleserver.domain.project.Project
 import com.project.scrumbleserver.repository.project.ProjectRepository
+import com.project.scrumbleserver.service.tag.TagService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class ProjectService(
     private val projectRepository: ProjectRepository,
+    private val tagService: TagService
 ) {
     @Transactional
     fun insert(
         request: ApiPostProjectRequest,
     ): ApiPostProjectResponse {
-        val project = Project(
+        val project = projectRepository.save(Project(
             title = request.title,
             description = request.description ?: ""
-        )
-        projectRepository.save(project)
+        ))
+
+        tagService.insert(project)
+
         return ApiPostProjectResponse(project.rowid)
     }
 

--- a/src/main/kotlin/com/project/scrumbleserver/service/tag/TagService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/tag/TagService.kt
@@ -1,0 +1,28 @@
+package com.project.scrumbleserver.service.tag
+
+import com.project.scrumbleserver.domain.project.Project
+import com.project.scrumbleserver.domain.tag.BasicTag
+import com.project.scrumbleserver.domain.tag.Tag
+import com.project.scrumbleserver.repository.tag.TagRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TagService(
+    private val tagRepository: TagRepository
+) {
+    @Transactional
+    fun insert(
+        project: Project,
+    ) {
+        BasicTag.entries.map { tag ->
+            tagRepository.save(
+                Tag(
+                    project = project,
+                    title = tag.title,
+                    color = tag.color
+                )
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/service/tag/TagService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/tag/TagService.kt
@@ -19,15 +19,14 @@ class TagService(
     fun insert(
         project: Project,
     ) {
-        BasicTag.entries.map { tag ->
-            tagRepository.save(
-                Tag(
-                    project = project,
-                    title = tag.title,
-                    color = tag.color
-                )
+        val tagList = BasicTag.entries.map { tag ->
+            Tag(
+                project = project,
+                title = tag.title,
+                color = tag.color
             )
         }
+        tagRepository.saveAll(tagList)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/project/scrumbleserver/service/tag/TagService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/tag/TagService.kt
@@ -1,14 +1,18 @@
 package com.project.scrumbleserver.service.tag
 
+import com.project.scrumbleserver.api.tag.ApiGetAllTagResponse
 import com.project.scrumbleserver.domain.project.Project
 import com.project.scrumbleserver.domain.tag.BasicTag
 import com.project.scrumbleserver.domain.tag.Tag
+import com.project.scrumbleserver.repository.project.ProjectRepository
 import com.project.scrumbleserver.repository.tag.TagRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 class TagService(
+    private val projectRepository: ProjectRepository,
     private val tagRepository: TagRepository
 ) {
     @Transactional
@@ -23,6 +27,28 @@ class TagService(
                     color = tag.color
                 )
             )
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun findAllByProjectRowid(
+        projectRowid: Long,
+    ): List<ApiGetAllTagResponse> {
+        val project = projectRepository.findById(projectRowid)
+            .getOrNull() ?: throw IllegalArgumentException("프로젝트를 찾을 수 없습니다. ID: $projectRowid")
+
+        val tags = tagRepository.findAllByProject(project)
+
+        return tags.map {
+            ApiGetAllTagResponse.Tag(
+                tagRowid = it.rowid,
+                projectRowid = it.project.rowid,
+                title = it.title,
+                color = it.color,
+                regDate = it.regDate
+            )
+        }.let { tagList ->
+            return listOf(ApiGetAllTagResponse(tagList))
         }
     }
 }


### PR DESCRIPTION
## 변경 사항

- Project가 등록될 때, 해당 프로젝트에 대한 기본 제공 태그 저장
   - Feature, Bug, Improvement, Refactor, Docs, Design, Test, Chore
- ProductBacklog 등록 Request에 Tag의 rowid 추가
- ProductBacklog 목록 Response에 Tag 정보 추가

## 고민 사항

- Tag 정보를 현재 Enum으로 관리 중
   - 만약, 정보 변경이 있을 시, 서버를 재배포 해야하는데, 이거를 DB에 저장해두는게 좋을지 고민해봐야할듯?

![image](https://github.com/user-attachments/assets/34b6cc82-93e0-4b90-986d-593e05b9dce1)
