### PR TITLE
ProductBacklog 목록 응답에 Tag 정보를 포함한다.

### DIFF
--- a/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiGetAllProductBacklog.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/productBacklog/ApiGetAllProductBacklog.kt
@@ -12,11 +12,17 @@ data class ApiGetAllProductBacklogRequest(
 data class ApiGetAllProductBacklogResponse(
     val productBacklogs: List<ProductBacklog>
 ) {
+    data class ProductBacklogTag(
+        val productBacklogTagRowid: Long,
+        val title: String,
+        val color: String
+    )
     data class ProductBacklog(
         val productBacklogRowid: Long,
         val title: String,
         val description: String,
         val priority: ProductBacklogPriority,
+        val tags: List<ProductBacklogTag>,
         val regDate: LocalDateTime
     )
 }

--- a/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
@@ -53,6 +53,13 @@ class ProductBacklogService(
                         title = it.title,
                         description = it.description,
                         priority = it.priority,
+                        tags = it.tags.map { productBacklogTag ->
+                            ApiGetAllProductBacklogResponse.ProductBacklogTag(
+                                productBacklogTagRowid = productBacklogTag.rowid,
+                                title = productBacklogTag.tag.title,
+                                color = productBacklogTag.tag.color
+                            )
+                        },
                         regDate = it.regDate
                     )
                 )


### PR DESCRIPTION
## 반영 사항

> 관련 이슈 : #31, #27, #32

- ProductBacklog 목록 응답에 Tag 정보 추가

![image](https://github.com/user-attachments/assets/f954cec9-deaf-4dab-9be8-8d672ab54f7f)