### PR TITLE
구글 로그인 기능을 도입한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+.env

--- a/src/main/kotlin/com/project/scrumbleserver/api/auth/ApiGoogleLogin.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/auth/ApiGoogleLogin.kt
@@ -1,0 +1,3 @@
+package com.project.scrumbleserver.api.auth
+
+const val API_GOOGLE_LOGIN_PATH = "/api/v1/auth/google/login"

--- a/src/main/kotlin/com/project/scrumbleserver/api/auth/ApiGoogleOauthCallback.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/auth/ApiGoogleOauthCallback.kt
@@ -1,0 +1,3 @@
+package com.project.scrumbleserver.api.auth
+
+const val API_GOOGLE_OAUTH_CALLBACK_PATH = "/api/v1/auth/google/callback"

--- a/src/main/kotlin/com/project/scrumbleserver/config/ApplicationConfig.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/config/ApplicationConfig.kt
@@ -1,0 +1,8 @@
+package com.project.scrumbleserver.config
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationPropertiesScan(basePackages = ["com.project.scrumbleserver"])
+class ApplicationConfig

--- a/src/main/kotlin/com/project/scrumbleserver/controller/auth/GoogleLoginController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/auth/GoogleLoginController.kt
@@ -1,0 +1,62 @@
+package com.project.scrumbleserver.controller.auth
+
+import com.project.scrumbleserver.api.auth.API_GOOGLE_LOGIN_PATH
+import com.project.scrumbleserver.api.auth.API_GOOGLE_OAUTH_CALLBACK_PATH
+import com.project.scrumbleserver.infra.oauth.google.GoogleOauthProperties
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+@RestController
+class GoogleLoginController(
+    private val googleOauthProperties: GoogleOauthProperties,
+) {
+    @GetMapping(API_GOOGLE_LOGIN_PATH)
+    fun googleLogin(
+        @RequestParam state: String,
+    ): ResponseEntity<Unit> {
+        println(state)
+        val googleAuthUrl = UriComponentsBuilder
+            .fromHttpUrl("https://accounts.google.com/o/oauth2/auth")
+            .queryParam("client_id", googleOauthProperties.clientId)
+            .queryParam("redirect_uri", googleOauthProperties.redirectUri)
+            .queryParam("response_type", "code")
+            .queryParam("scope", googleOauthProperties.scope)
+            .queryParam("state", state)
+            .build()
+            .toUriString()
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .location(URI.create(googleAuthUrl))
+            .build()
+    }
+
+    @GetMapping(API_GOOGLE_OAUTH_CALLBACK_PATH)
+    fun googleLoginCallback(
+        @RequestParam code: String,
+        @RequestParam state: String,
+        httpResponse: HttpServletResponse,
+    ): ResponseEntity<Unit> {
+        Cookie("access_token", "access-token").apply {
+            path = "/"
+            isHttpOnly = true
+            secure = true
+            maxAge = 3600
+        }.also { cookie ->
+            httpResponse.addCookie(cookie)
+        }
+
+        val redirectUri = URLDecoder.decode(state, StandardCharsets.UTF_8)
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .location(URI.create(redirectUri))
+            .build()
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/infra/oauth/google/GoogleAuthenticator.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/infra/oauth/google/GoogleAuthenticator.kt
@@ -1,0 +1,97 @@
+package com.project.scrumbleserver.infra.oauth.google
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.project.scrumbleserver.global.excception.BusinessException
+import com.project.scrumbleserver.global.excception.ServerException
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestTemplate
+import java.net.URI
+
+@Component
+class GoogleAuthenticator(
+    private val restTemplate: RestTemplate,
+    private val googleOauthProperties: GoogleOauthProperties,
+) {
+    companion object {
+        private const val GOOGLE_AUTH_API_ENDPOINT = "https://oauth2.googleapis.com/token"
+        private const val GOOGLE_USER_API_ENDPOINT = "https://www.googleapis.com/oauth2/v2/userinfo"
+    }
+
+    private data class AuthResponse(
+        @JsonProperty("access_token")
+        val accessToken: String,
+    )
+
+    fun authenticate(code: String): String {
+        val accessToken = callAuthApi(code)
+        return callUserInfoApi(accessToken)
+    }
+
+    private fun callAuthApi(code: String): String {
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_FORM_URLENCODED
+            charset("UTF-8")
+        }
+
+        val body = LinkedMultiValueMap<String, String>().apply {
+            add("code", code)
+            add("client_id", googleOauthProperties.clientId)
+            add("client_secret", googleOauthProperties.clientSecret)
+            add("redirect_uri", googleOauthProperties.redirectUri)
+            add("grant_type", "authorization_code")
+        }
+
+        val request = HttpEntity(body, headers)
+        val response = restTemplate.exchange(
+            GOOGLE_AUTH_API_ENDPOINT,
+            HttpMethod.POST,
+            request,
+            AuthResponse::class.java
+        )
+
+        if (response.statusCode.isError) {
+            throw BusinessException("구글 인증 요청에 실패했습니다.")
+        }
+
+        return response.body?.accessToken ?: throw ServerException("구글로 부터 사용자 인증 정보를 가져오는데 실패했습니다.")
+    }
+
+    data class GoogleUserInfo(
+        val id: String,
+        val email: String,
+        @JsonProperty("verified_email")
+        val verifiedEmail: Boolean,
+        val name: String,
+        @JsonProperty("given_name")
+        val givenName: String,
+        @JsonProperty("family_name")
+        val familyName: String,
+        val picture: String
+    )
+
+    fun callUserInfoApi(accessToken: String): String {
+        val headers = HttpHeaders().apply {
+            setBearerAuth(accessToken)
+        }
+
+        val request = HttpEntity<Unit>(headers)
+
+        val response = restTemplate.exchange(
+            URI(GOOGLE_USER_API_ENDPOINT),
+            HttpMethod.GET,
+            request,
+            GoogleUserInfo::class.java
+        )
+
+        if (response.statusCode.isError) {
+            throw BusinessException("구글 사용자 정보 요청에 실패했습니다.")
+        }
+
+        return response.body?.email ?: throw ServerException("구글로 부터 사용자 정보를 가져오는데 실패했습니다.")
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/infra/oauth/google/GoogleOauthProperties.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/infra/oauth/google/GoogleOauthProperties.kt
@@ -1,0 +1,11 @@
+package com.project.scrumbleserver.infra.oauth.google
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("oauth.google")
+data class GoogleOauthProperties(
+    val clientId: String,
+    val clientSecret: String,
+    val redirectUri: String,
+    val scope: String,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,10 @@ management:
 
 server:
   port: 8080
+
+oauth:
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
+    scope: ${GOOGLE_SCOPE}
+    client-secret: ${GOOGLE_CLIENT_SECRET}


### PR DESCRIPTION
## 📌 개요 (Summary)
- 구글로 부터 인증을 진행하고, 유저 정보를 가져오는 기능을 추가하였습니다.

## ✨ 변경사항 (Changes)
- [X] 주요 기능 구현
- [ ] API 스펙 변경
- [ ] 버그 수정
- [ ] 테스트 코드 추가/수정
- 기타:

## 🧩 관련 이슈 (Related Issues)
- close #44

## 🔍 주요 작업 내역 (What I Did)
- 구글 oauth2 Api 연동
- GoogleLoginController에 구글 로그인 Api 2개 (googleLogin, googleLoginCallback) 추가

## ❗️리뷰 시 유의사항 (Notice for Reviewer)
- 지난번에 리뷰 해주신 `WebClient`을 사용해 보려 했지만 webflux 의존성이 필요해서 `RestTemplate`으로 유지 했습니다. 이후에 webflux를 도입 하게 되면 그때 변경 하는게 좋을 것 같아요 !
- 스크럼블 노션 '인프라 명세서 > Server Env'에 필요한 환경변수들 정리 해두었습니다. 이후 작업 진행 시 추가해 주세요
