### PR TITLE
Jwt 토큰을 발급할 수 있다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     implementation("io.github.microutils:kotlin-logging:3.0.5")
 
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
     runtimeOnly("com.mysql:mysql-connector-j")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/project/scrumbleserver/controller/handler/ApiControllerAdvice.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/handler/ApiControllerAdvice.kt
@@ -1,8 +1,8 @@
 package com.project.scrumbleserver.controller.handler
 
 import com.project.scrumbleserver.global.api.ApiResponse
-import com.project.scrumbleserver.global.excception.BusinessException
-import com.project.scrumbleserver.global.excception.ServerException
+import com.project.scrumbleserver.global.exception.BusinessException
+import com.project.scrumbleserver.global.exception.ServerException
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -16,7 +16,7 @@ private val logger = KotlinLogging.logger {}
 class ApiControllerAdvice {
 
     data class ErrorResponse(
-        val message: String
+        val message: String,
     )
 
     @ExceptionHandler(BusinessException::class)

--- a/src/main/kotlin/com/project/scrumbleserver/domain/member/Member.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/member/Member.kt
@@ -17,8 +17,11 @@ class Member(
     var email: String,
 
     @Column(nullable = false, length = 50)
-    var nickname: String,
+    var nickname: String = "",
 
     @Column(nullable = false, length = 30)
-    var job: String,
-)
+    var job: String = "",
+) {
+    val isInfoEmpty
+        get() = nickname.isEmpty() || job.isEmpty()
+}

--- a/src/main/kotlin/com/project/scrumbleserver/domain/member/MemberRepository.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/member/MemberRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface MemberRepository : JpaRepository<Member, Long>
+interface MemberRepository : JpaRepository<Member, Long> {
+    fun findByEmail(email: String): Member?
+}

--- a/src/main/kotlin/com/project/scrumbleserver/global/exception/BusinessException.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/global/exception/BusinessException.kt
@@ -1,4 +1,4 @@
-package com.project.scrumbleserver.global.excception
+package com.project.scrumbleserver.global.exception
 
 import org.springframework.http.HttpStatus
 

--- a/src/main/kotlin/com/project/scrumbleserver/global/exception/ForbiddenException.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/global/exception/ForbiddenException.kt
@@ -1,0 +1,5 @@
+package com.project.scrumbleserver.global.exception
+
+class ForbiddenException(
+    override val message: String = "forbidden"
+) : Exception(message)

--- a/src/main/kotlin/com/project/scrumbleserver/global/exception/ServerException.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/global/exception/ServerException.kt
@@ -1,4 +1,4 @@
-package com.project.scrumbleserver.global.excception
+package com.project.scrumbleserver.global.exception
 
 class ServerException(
     override val message: String = "unknown error occurred"

--- a/src/main/kotlin/com/project/scrumbleserver/global/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/global/exception/UnauthorizedException.kt
@@ -1,0 +1,5 @@
+package com.project.scrumbleserver.global.exception
+
+class UnauthorizedException(
+    override val message: String = "unauthorized"
+) : Exception(message)

--- a/src/main/kotlin/com/project/scrumbleserver/global/transaction/Transaction.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/global/transaction/Transaction.kt
@@ -1,6 +1,6 @@
 package com.project.scrumbleserver.global.transaction
 
-import com.project.scrumbleserver.global.excception.ServerException
+import com.project.scrumbleserver.global.exception.ServerException
 import org.springframework.stereotype.Component
 import org.springframework.transaction.support.TransactionTemplate
 

--- a/src/main/kotlin/com/project/scrumbleserver/infra/cache/CacheStorage.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/infra/cache/CacheStorage.kt
@@ -1,0 +1,13 @@
+package com.project.scrumbleserver.infra.cache
+
+interface CacheStorage {
+    companion object {
+        private const val ONE_DAY = 3600L * 24L
+    }
+
+    fun put(key: String, value: String, expiration: Long = ONE_DAY)
+
+    fun get(key: String): String?
+
+    fun remove(key: String)
+}

--- a/src/main/kotlin/com/project/scrumbleserver/infra/cache/inmemory/InMemoryCacheStorage.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/infra/cache/inmemory/InMemoryCacheStorage.kt
@@ -1,0 +1,43 @@
+package com.project.scrumbleserver.infra.cache.inmemory
+
+import com.project.scrumbleserver.infra.cache.CacheStorage
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class InMemoryCacheStorage : CacheStorage {
+    private val storage = ConcurrentHashMap<String, CacheEntry>()
+
+    private data class CacheEntry(
+        val value: String,
+        private val expiredAt: Long,
+    ) {
+        companion object {
+            fun of(value: String, expiration: Long): CacheEntry {
+                return CacheEntry(value, System.currentTimeMillis() + expiration)
+            }
+        }
+
+        val isExpired: Boolean
+            get() = System.currentTimeMillis() > expiredAt
+    }
+
+    override fun put(key: String, value: String, expiration: Long) {
+        storage[key] = CacheEntry.of(value, expiration)
+    }
+
+    override fun get(key: String): String? {
+        return storage[key]?.let {
+            if (it.isExpired) {
+                storage.remove(key)
+                null
+            } else {
+                it.value
+            }
+        }
+    }
+
+    override fun remove(key: String) {
+        storage.remove(key)
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/infra/jwt/JwtProperties.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/infra/jwt/JwtProperties.kt
@@ -1,0 +1,15 @@
+package com.project.scrumbleserver.infra.jwt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("jwt")
+data class JwtProperties(
+    val secret: String
+) {
+    companion object {
+        const val ONE_HOUR = 3600L
+        const val SEVEN_DAYS = 604800L
+    }
+
+    val tokenExpires = ONE_HOUR
+}

--- a/src/main/kotlin/com/project/scrumbleserver/infra/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/infra/jwt/JwtTokenProvider.kt
@@ -1,0 +1,47 @@
+package com.project.scrumbleserver.infra.jwt
+
+import com.project.scrumbleserver.global.exception.UnauthorizedException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.util.Date
+import java.util.UUID
+import javax.crypto.SecretKey
+
+@Component
+class JwtTokenProvider(
+    private val jwtProperties: JwtProperties,
+) {
+    private val key: SecretKey = Keys.hmacShaKeyFor(jwtProperties.secret.toByteArray())
+
+    fun provideAccessToken(userId: Long): String {
+        val now = Date()
+        val expiryDate = Date(now.time + jwtProperties.tokenExpires)
+
+        return Jwts.builder()
+            .setSubject(userId.toString())
+            .setIssuedAt(now)
+            .setExpiration(expiryDate)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    fun provideRefreshToken(): String {
+        return UUID.randomUUID().toString()
+    }
+
+    fun decodeToken(token: String): Long {
+        val claims = try {
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .body
+        } catch (e: Exception) {
+            throw UnauthorizedException("유효하지 않은 인증 토큰 입니다.")
+        }
+
+        return claims.subject.toLongOrNull() ?: throw UnauthorizedException("유효하지 않은 인증 토큰 입니다.")
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/infra/oauth/google/GoogleAuthenticator.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/infra/oauth/google/GoogleAuthenticator.kt
@@ -1,8 +1,7 @@
 package com.project.scrumbleserver.infra.oauth.google
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.project.scrumbleserver.global.excception.BusinessException
-import com.project.scrumbleserver.global.excception.ServerException
+import com.project.scrumbleserver.global.exception.UnauthorizedException
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -55,10 +54,10 @@ class GoogleAuthenticator(
         )
 
         if (response.statusCode.isError) {
-            throw BusinessException("구글 인증 요청에 실패했습니다.")
+            throw UnauthorizedException("구글 인증 요청에 실패했습니다.")
         }
 
-        return response.body?.accessToken ?: throw ServerException("구글로 부터 사용자 인증 정보를 가져오는데 실패했습니다.")
+        return response.body?.accessToken ?: throw UnauthorizedException("구글로 부터 사용자 인증 정보를 가져오는데 실패했습니다.")
     }
 
     data class GoogleUserInfo(
@@ -71,7 +70,7 @@ class GoogleAuthenticator(
         val givenName: String,
         @JsonProperty("family_name")
         val familyName: String,
-        val picture: String
+        val picture: String,
     )
 
     fun callUserInfoApi(accessToken: String): String {
@@ -89,9 +88,9 @@ class GoogleAuthenticator(
         )
 
         if (response.statusCode.isError) {
-            throw BusinessException("구글 사용자 정보 요청에 실패했습니다.")
+            throw UnauthorizedException("구글 사용자 정보 요청에 실패했습니다.")
         }
 
-        return response.body?.email ?: throw ServerException("구글로 부터 사용자 정보를 가져오는데 실패했습니다.")
+        return response.body?.email ?: throw UnauthorizedException("구글로 부터 사용자 정보를 가져오는데 실패했습니다.")
     }
 }

--- a/src/main/kotlin/com/project/scrumbleserver/infra/storage/ImageUploader.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/infra/storage/ImageUploader.kt
@@ -1,6 +1,6 @@
 package com.project.scrumbleserver.infra.storage
 
-import com.project.scrumbleserver.global.excception.BusinessException
+import com.project.scrumbleserver.global.exception.BusinessException
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod

--- a/src/main/kotlin/com/project/scrumbleserver/service/auth/AuthService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/auth/AuthService.kt
@@ -1,0 +1,57 @@
+package com.project.scrumbleserver.service.auth
+
+import com.project.scrumbleserver.domain.member.Member
+import com.project.scrumbleserver.domain.member.MemberRepository
+import com.project.scrumbleserver.global.exception.BusinessException
+import com.project.scrumbleserver.global.transaction.Transaction
+import com.project.scrumbleserver.infra.cache.CacheStorage
+import com.project.scrumbleserver.infra.jwt.JwtTokenProvider
+import com.project.scrumbleserver.infra.oauth.google.GoogleAuthenticator
+import org.springframework.stereotype.Service
+
+@Service
+class AuthService(
+    private val memberRepository: MemberRepository,
+    private val googleAuthenticator: GoogleAuthenticator,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val cacheStorage: CacheStorage,
+    private val transaction: Transaction,
+) {
+    companion object {
+        private const val REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN_"
+        private const val SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000L
+    }
+
+    data class AuthToken(
+        val accessToken: String,
+        val refreshToken: String,
+    )
+
+    fun login(code: String): AuthToken {
+        val userEmail = googleAuthenticator.authenticate(code)
+        val member = transaction {
+            memberRepository.findByEmail(userEmail) ?: run {
+                memberRepository.save(Member(email = userEmail))
+            }
+        }
+
+        val accessToken = jwtTokenProvider.provideAccessToken(member.rowid)
+        val refreshToken = jwtTokenProvider.provideRefreshToken()
+
+        cacheStorage.put("${REFRESH_TOKEN_PREFIX}${refreshToken}", member.rowid.toString(), SEVEN_DAYS)
+
+        return AuthToken(accessToken, refreshToken)
+    }
+
+    fun refresh(refreshToken: String): AuthToken {
+        val memberId = cacheStorage.get("${REFRESH_TOKEN_PREFIX}${refreshToken}")?.toLongOrNull()
+            ?: throw BusinessException("유효하지 않은 인증 정보 입니다.")
+
+        val accessToken = jwtTokenProvider.provideAccessToken(memberId)
+        val refreshToken = jwtTokenProvider.provideRefreshToken()
+
+        cacheStorage.put("${REFRESH_TOKEN_PREFIX}${refreshToken}", memberId.toString(), SEVEN_DAYS)
+
+        return AuthToken(accessToken, refreshToken)
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
@@ -3,7 +3,7 @@ package com.project.scrumbleserver.service.productBacklog
 import com.project.scrumbleserver.api.productBacklog.ApiGetAllProductBacklog
 import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklogRequest
 import com.project.scrumbleserver.domain.productBacklog.ProductBacklog
-import com.project.scrumbleserver.global.excception.BusinessException
+import com.project.scrumbleserver.global.exception.BusinessException
 import com.project.scrumbleserver.repository.productBacklog.ProductBacklogRepository
 import com.project.scrumbleserver.repository.project.ProjectRepository
 import org.springframework.data.repository.findByIdOrNull

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
@@ -41,3 +41,6 @@ oauth:
     redirect-uri: ${GOOGLE_REDIRECT_URI}
     scope: ${GOOGLE_SCOPE}
     client-secret: ${GOOGLE_CLIENT_SECRET}
+
+jwt:
+  secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📌 개요 (Summary)
- 어떤 기능/수정/리팩터링 작업을 했는지 간단히 설명해주세요.

## ✨ 변경사항 (Changes)
- [X] 주요 기능 구현
- [ ] API 스펙 변경
- [ ] 버그 수정
- [ ] 테스트 코드 추가/수정
- 기타:

## 🧩 관련 이슈 (Related Issues)
- close #49 

## 🔍 주요 작업 내역 (What I Did)
- Jwt 토큰 발급 기능 추가
- 인메모리 캐시 도입
- 구글로그인 시 자체 토큰 발급 후 쿠키 저장 기능 추가

## ❗️리뷰 시 유의사항 (Notice for Reviewer)
- 레디스 도입 전까지 인메모리 캐시 도입 하였습니다.
- 구글에서 발급해 주는 토큰을 계속 사용하면 저희 스크럼블로 오는 api 요청마다 구글 api를 두 번(auth -> userInfo) 호출 해야 해서 로그인 시에만 구글을 다녀오고, 이후에는 저희가 토큰을 새로 발급해 주는 방법으로 구현 하였습니다.
