### PR TITLE
프로젝트 생성한 회원을 프로젝트의 OWNER로 지정한다.

### DIFF
--- a/src/main/kotlin/com/project/scrumbleserver/controller/project/ProjectController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/project/ProjectController.kt
@@ -6,6 +6,7 @@ import com.project.scrumbleserver.api.project.ApiGetAllProjectResponse
 import com.project.scrumbleserver.api.project.ApiPostProjectRequest
 import com.project.scrumbleserver.api.project.ApiPostProjectResponse
 import com.project.scrumbleserver.global.api.ApiResponse
+import com.project.scrumbleserver.security.RequestUserRowid
 import com.project.scrumbleserver.service.project.ProjectService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -30,8 +31,9 @@ class ProjectController(
     fun add(
         @RequestPart("thumbnail", required = false) thumbnail: MultipartFile?,
         @RequestPart("request") @Valid request: ApiPostProjectRequest,
+        @RequestUserRowid userRowid: Long,
     ): ApiResponse<ApiPostProjectResponse> {
-        val response = projectService.insert(thumbnail, request)
+        val response = projectService.insert(thumbnail, request, userRowid)
         return ApiResponse.of(response)
     }
 

--- a/src/main/kotlin/com/project/scrumbleserver/domain/project/Project.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/project/Project.kt
@@ -1,6 +1,7 @@
 package com.project.scrumbleserver.domain.project
 
 import com.project.scrumbleserver.domain.BaseEntity
+import com.project.scrumbleserver.domain.member.Member
 import jakarta.persistence.*
 
 @Entity
@@ -17,5 +18,9 @@ class Project(
     var description: String,
 
     @Column(nullable = false, length = 1000)
-    var thumbnail: String
+    var thumbnail: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_rowid", nullable = false)
+    val owner: Member,
 ) : BaseEntity()


### PR DESCRIPTION
## 📌 개요 (Summary)
- 프로젝트를 생성한 회원이 프로젝트의 owner 로 등록할 수 있는 기능 추가.

## ✨ 변경사항 (Changes)
- [X] 주요 기능 구현
- [ ] API 스펙 변경
- [ ] 버그 수정
- [ ] 테스트 코드 추가/수정
- 기타:

## 🧩 관련 이슈 (Related Issues)
- resolve #60 

## 🔍 주요 작업 내역 (What I Did)
- `Project` : 프로젝트엔티티에 Owner 필드를 추가함
- `ProjectService` : 프로젝트를 생성한 사람이 owner가 되도록 수정함

## ❗️리뷰 시 유의사항 (Notice for Reviewer)
- 컨트롤러에서 요청한 유저의 rowid를 불러올 수 있는 코드의 예시로 이번 수정 사항 확인 하시면 될 것 같습니다 ~!
