### PR TITLE
프로젝트를 생성한 회원을 프로젝트의 OWNER로 지정한다.

### DIFF
--- a/src/main/kotlin/com/project/scrumbleserver/api/projectInvite/ApiGetProjectInviteAccept.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/projectInvite/ApiGetProjectInviteAccept.kt
@@ -1,0 +1,7 @@
+package com.project.scrumbleserver.api.projectInvite
+
+const val API_POST_PROJECT_INVITE_ACCEPT_PATH = "/api/v1/project-invite/{code}/accept"
+
+data class ApiPostProjectInviteAcceptResponse(
+    val projectInviteRowid: Long,
+)

--- a/src/main/kotlin/com/project/scrumbleserver/api/projectInvite/ApiPostProjectInvite.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/projectInvite/ApiPostProjectInvite.kt
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
-const val API_POST_PROJECT_INVITE_PATH = "/api/v1/project/invite"
+const val API_POST_PROJECT_INVITE_PATH = "/api/v1/project-invite"
 
 data class ApiPostProjectInviteRequest(
     @field:NotBlank(message = "이메일은 필수입니다.")

--- a/src/main/kotlin/com/project/scrumbleserver/api/projectMember/ApiPutProject.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/projectMember/ApiPutProject.kt
@@ -1,0 +1,21 @@
+package com.project.scrumbleserver.api.projectMember
+
+import com.project.scrumbleserver.domain.projectMember.ProjectMemberPermission
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+const val API_PUT_PROJECT_MEMBER_PERMISSION_PATH = "/api/v1/project-member/permission"
+
+data class ApiPutProjectMemberPermissionRequest(
+    @field:NotNull(message = "projectRowid는 필수입니다.")
+    val projectRowid: Long,
+    @field:NotNull(message = "memberRowid는 필수입니다.")
+    val memberRowid: Long,
+    @field:NotBlank(message = "permission은 필수입니다.")
+    val permission: ProjectMemberPermission
+)
+
+data class ApiPutProjectMemberPermissionResponse(
+    val projectMemberRowid: Long,
+)

--- a/src/main/kotlin/com/project/scrumbleserver/controller/project/ProjectController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/project/ProjectController.kt
@@ -6,6 +6,7 @@ import com.project.scrumbleserver.api.project.ApiGetAllProjectResponse
 import com.project.scrumbleserver.api.project.ApiPostProjectRequest
 import com.project.scrumbleserver.api.project.ApiPostProjectResponse
 import com.project.scrumbleserver.global.api.ApiResponse
+import com.project.scrumbleserver.security.RequestUserRowid
 import com.project.scrumbleserver.service.project.ProjectService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -30,8 +31,9 @@ class ProjectController(
     fun add(
         @RequestPart("thumbnail", required = false) thumbnail: MultipartFile?,
         @RequestPart("request") @Valid request: ApiPostProjectRequest,
+        @RequestUserRowid userRowid: Long,
     ): ApiResponse<ApiPostProjectResponse> {
-        val response = projectService.insert(thumbnail, request)
+        val response = projectService.insert(thumbnail, request, userRowid)
         return ApiResponse.of(response)
     }
 

--- a/src/main/kotlin/com/project/scrumbleserver/controller/project/ProjectController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/project/ProjectController.kt
@@ -1,10 +1,6 @@
 package com.project.scrumbleserver.controller.project
 
-import com.project.scrumbleserver.api.project.API_GET_ALL_PROJECT_PATH
-import com.project.scrumbleserver.api.project.API_POST_PROJECT_PATH
-import com.project.scrumbleserver.api.project.ApiGetAllProjectResponse
-import com.project.scrumbleserver.api.project.ApiPostProjectRequest
-import com.project.scrumbleserver.api.project.ApiPostProjectResponse
+import com.project.scrumbleserver.api.project.*
 import com.project.scrumbleserver.global.api.ApiResponse
 import com.project.scrumbleserver.security.RequestUserRowid
 import com.project.scrumbleserver.service.project.ProjectService

--- a/src/main/kotlin/com/project/scrumbleserver/controller/projectInvite/ProjectInviteController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/projectInvite/ProjectInviteController.kt
@@ -1,25 +1,16 @@
 package com.project.scrumbleserver.controller.projectInvite
 
-import com.project.scrumbleserver.api.project.API_GET_ALL_PROJECT_PATH
-import com.project.scrumbleserver.api.project.API_POST_PROJECT_PATH
-import com.project.scrumbleserver.api.project.ApiGetAllProjectResponse
-import com.project.scrumbleserver.api.project.ApiPostProjectRequest
-import com.project.scrumbleserver.api.project.ApiPostProjectResponse
-import com.project.scrumbleserver.api.projectInvite.API_POST_PROJECT_INVITE_PATH
-import com.project.scrumbleserver.api.projectInvite.ApiPostProjectInviteRequest
-import com.project.scrumbleserver.api.projectInvite.ApiPostProjectInviteResponse
+import com.project.scrumbleserver.api.projectInvite.*
 import com.project.scrumbleserver.global.api.ApiResponse
-import com.project.scrumbleserver.service.project.ProjectService
 import com.project.scrumbleserver.service.projectInvite.ProjectInviteService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @Tag(name = "Project", description = "프로젝트 초대 관련 API")
@@ -38,5 +29,17 @@ class ProjectInviteController(
     ): ApiResponse<ApiPostProjectInviteResponse> {
         val response = projectInviteService.invite(request.projectRowid, request.email)
         return ApiResponse.of(ApiPostProjectInviteResponse(response))
+    }
+
+    @PostMapping(API_POST_PROJECT_INVITE_ACCEPT_PATH)
+    @Operation(
+        summary = "프로젝트 초대 수락",
+        description = "초대 코드를 통해 프로젝트에 참여합니다.",
+    )
+    fun inviteAccept(
+        @PathVariable code: String
+    ): ApiResponse<ApiPostProjectInviteAcceptResponse> {
+        val response = projectInviteService.inviteAccept(code)
+        return ApiResponse.of(ApiPostProjectInviteAcceptResponse(response))
     }
 }

--- a/src/main/kotlin/com/project/scrumbleserver/controller/projectMember/ProjectMemberController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/projectMember/ProjectMemberController.kt
@@ -1,0 +1,41 @@
+package com.project.scrumbleserver.controller.projectMember
+
+import com.project.scrumbleserver.api.project.*
+import com.project.scrumbleserver.api.projectMember.API_PUT_PROJECT_MEMBER_PERMISSION_PATH
+import com.project.scrumbleserver.api.projectMember.ApiPutProjectMemberPermissionRequest
+import com.project.scrumbleserver.api.projectMember.ApiPutProjectMemberPermissionResponse
+import com.project.scrumbleserver.global.api.ApiResponse
+import com.project.scrumbleserver.security.RequestUserRowid
+import com.project.scrumbleserver.service.project.ProjectService
+import com.project.scrumbleserver.service.projectMember.ProjectMemberService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@Tag(name = "ProjectMember", description = "프로젝트 회원 관련 API")
+class ProjectMemberController(
+    private val projectMemberService: ProjectMemberService,
+) {
+    @PutMapping(API_PUT_PROJECT_MEMBER_PERMISSION_PATH)
+    @Operation(
+        summary = "프로젝트 회원 권한 수정",
+        description = "프로젝트에 속한 회원의 권한을 수정합니다.",
+    )
+    fun edit(
+        @RequestBody @Valid
+        request: ApiPutProjectMemberPermissionRequest,
+        @RequestUserRowid userRowid: Long
+    ): ApiResponse<ApiPutProjectMemberPermissionResponse> {
+        val projectMemberRowid = projectMemberService.edit(request.projectRowid, request.memberRowid, request.permission, userRowid)
+        val response = ApiPutProjectMemberPermissionResponse(projectMemberRowid)
+        return ApiResponse.of(response)
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/domain/projectMember/ProjectMember.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/projectMember/ProjectMember.kt
@@ -2,10 +2,7 @@ package com.project.scrumbleserver.domain.projectMember
 
 import com.project.scrumbleserver.domain.BaseEntity
 import com.project.scrumbleserver.domain.member.Member
-import com.project.scrumbleserver.domain.productBacklog.ProductBacklog
-import com.project.scrumbleserver.domain.productBacklog.ProductBacklogPriority
 import com.project.scrumbleserver.domain.project.Project
-import com.project.scrumbleserver.domain.tag.Tag
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -34,5 +31,5 @@ class ProjectMember(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
-    var permission: ProductMemberPermission = ProductMemberPermission.CAN_VIEW
+    var permission: ProjectMemberPermission = ProjectMemberPermission.CAN_VIEW
 ) : BaseEntity()

--- a/src/main/kotlin/com/project/scrumbleserver/domain/projectMember/ProjectMemberPermission.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/projectMember/ProjectMemberPermission.kt
@@ -1,5 +1,5 @@
 package com.project.scrumbleserver.domain.projectMember
 
-enum class ProductMemberPermission {
+enum class ProjectMemberPermission {
     OWNER, CAN_EDIT, CAN_VIEW;
 }

--- a/src/main/kotlin/com/project/scrumbleserver/repository/projectInvite/ProjectInviteRepository.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/repository/projectInvite/ProjectInviteRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface ProjectInviteRepository : JpaRepository<ProjectInvite, Long> {
+    fun findByUuid(uuid: String): ProjectInvite?
 }

--- a/src/main/kotlin/com/project/scrumbleserver/repository/projectMember/ProjectMemberRepository.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/repository/projectMember/ProjectMemberRepository.kt
@@ -1,0 +1,8 @@
+package com.project.scrumbleserver.repository.projectMember
+
+import com.project.scrumbleserver.domain.projectMember.ProjectMember
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProjectMemberRepository : JpaRepository<ProjectMember, Long>

--- a/src/main/kotlin/com/project/scrumbleserver/repository/projectMember/ProjectMemberRepository.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/repository/projectMember/ProjectMemberRepository.kt
@@ -1,8 +1,13 @@
 package com.project.scrumbleserver.repository.projectMember
 
+import com.project.scrumbleserver.domain.member.Member
+import com.project.scrumbleserver.domain.project.Project
 import com.project.scrumbleserver.domain.projectMember.ProjectMember
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ProjectMemberRepository : JpaRepository<ProjectMember, Long>
+interface ProjectMemberRepository : JpaRepository<ProjectMember, Long> {
+    fun findByProjectAndMember(project: Project, member: Member): ProjectMember?
+    fun findByProject(project: Project): List<ProjectMember>
+}

--- a/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/productBacklog/ProductBacklogService.kt
@@ -4,7 +4,7 @@ import com.project.scrumbleserver.api.productBacklog.ApiGetAllProductBacklogResp
 import com.project.scrumbleserver.api.productBacklog.ApiPostProductBacklogRequest
 import com.project.scrumbleserver.domain.productBacklog.ProductBacklog
 import com.project.scrumbleserver.domain.tag.Tag
-import com.project.scrumbleserver.global.excception.BusinessException
+import com.project.scrumbleserver.global.exception.BusinessException
 import com.project.scrumbleserver.repository.productBacklog.ProductBacklogRepository
 import com.project.scrumbleserver.repository.project.ProjectRepository
 import com.project.scrumbleserver.service.tag.ProductBacklogTagService

--- a/src/main/kotlin/com/project/scrumbleserver/service/project/ProjectService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/project/ProjectService.kt
@@ -4,12 +4,12 @@ import com.project.scrumbleserver.api.project.ApiGetAllProjectResponse
 import com.project.scrumbleserver.api.project.ApiPostProjectRequest
 import com.project.scrumbleserver.api.project.ApiPostProjectResponse
 import com.project.scrumbleserver.domain.project.Project
-import com.project.scrumbleserver.domain.projectMember.ProjectMemberPermission
 import com.project.scrumbleserver.domain.projectMember.ProjectMember
-import com.project.scrumbleserver.infra.storage.ImageUploader
-import com.project.scrumbleserver.repository.project.ProjectRepository
+import com.project.scrumbleserver.domain.projectMember.ProjectMemberPermission
 import com.project.scrumbleserver.global.transaction.Transaction
+import com.project.scrumbleserver.infra.storage.ImageUploader
 import com.project.scrumbleserver.repository.member.MemberRepository
+import com.project.scrumbleserver.repository.project.ProjectRepository
 import com.project.scrumbleserver.repository.projectMember.ProjectMemberRepository
 import com.project.scrumbleserver.service.tag.TagService
 import org.springframework.data.repository.findByIdOrNull

--- a/src/main/kotlin/com/project/scrumbleserver/service/project/ProjectService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/project/ProjectService.kt
@@ -6,6 +6,7 @@ import com.project.scrumbleserver.api.project.ApiPostProjectResponse
 import com.project.scrumbleserver.domain.project.Project
 import com.project.scrumbleserver.domain.projectMember.ProjectMember
 import com.project.scrumbleserver.domain.projectMember.ProjectMemberPermission
+import com.project.scrumbleserver.global.exception.BusinessException
 import com.project.scrumbleserver.global.transaction.Transaction
 import com.project.scrumbleserver.infra.storage.ImageUploader
 import com.project.scrumbleserver.repository.member.MemberRepository
@@ -38,7 +39,7 @@ class ProjectService(
 
         val thumbnailUrl = imageUploader.upload(thumbnailData)
 
-        val member = memberRepository.findByIdOrNull(userRowid) ?: throw IllegalArgumentException("Member with rowid $userRowid not found")
+        val member = memberRepository.findByIdOrNull(userRowid) ?: throw BusinessException("Member with rowid $userRowid not found")
 
         val project = projectRepository.save(Project(
             title = request.title,

--- a/src/main/kotlin/com/project/scrumbleserver/service/projectInvite/ProjectInviteService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/projectInvite/ProjectInviteService.kt
@@ -1,11 +1,14 @@
 package com.project.scrumbleserver.service.projectInvite
 
-import com.project.scrumbleserver.domain.member.MemberRepository
 import com.project.scrumbleserver.domain.projectInvite.ProjectInvite
+import com.project.scrumbleserver.domain.projectMember.ProjectMember
+import com.project.scrumbleserver.domain.projectMember.ProjectMemberPermission
 import com.project.scrumbleserver.global.exception.BusinessException
 import com.project.scrumbleserver.global.transaction.Transaction
+import com.project.scrumbleserver.repository.member.MemberRepository
 import com.project.scrumbleserver.repository.project.ProjectRepository
 import com.project.scrumbleserver.repository.projectInvite.ProjectInviteRepository
+import com.project.scrumbleserver.repository.projectMember.ProjectMemberRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -14,6 +17,7 @@ class ProjectInviteService(
     private val transaction: Transaction,
     private val projectRepository: ProjectRepository,
     private val projectInviteRepository: ProjectInviteRepository,
+    private val projectMemberRepository: ProjectMemberRepository,
     private val memberRepository: MemberRepository
 ) {
     fun invite(
@@ -37,5 +41,22 @@ class ProjectInviteService(
         }
 
         return projectInviteRowid
+    }
+
+    fun inviteAccept(
+        code: String
+    ): Long = transaction {
+        val projectInvite = projectInviteRepository.findByUuid(code)
+            ?: throw BusinessException("초대 코드를 찾을 수 없습니다.")
+
+        val projectMember = projectMemberRepository.save(
+            ProjectMember(
+                project = projectInvite.project,
+                member = projectInvite.member,
+                permission = ProjectMemberPermission.CAN_VIEW
+            )
+        )
+
+        projectMember.rowid
     }
 }

--- a/src/main/kotlin/com/project/scrumbleserver/service/projectMember/ProjectMemberService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/projectMember/ProjectMemberService.kt
@@ -1,0 +1,68 @@
+package com.project.scrumbleserver.service.projectMember
+
+import com.project.scrumbleserver.domain.projectMember.ProjectMember
+import com.project.scrumbleserver.domain.projectMember.ProjectMemberPermission
+import com.project.scrumbleserver.global.exception.BusinessException
+import com.project.scrumbleserver.global.transaction.Transaction
+import com.project.scrumbleserver.repository.member.MemberRepository
+import com.project.scrumbleserver.repository.project.ProjectRepository
+import com.project.scrumbleserver.repository.projectMember.ProjectMemberRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class ProjectMemberService(
+    private val transaction: Transaction,
+    private val projectRepository: ProjectRepository,
+    private val projectMemberRepository: ProjectMemberRepository,
+    private val memberRepository: MemberRepository
+) {
+    companion object {
+        private const val MEMBER_NOT_FOUND_MSG = "존재하지 않는 회원입니다."
+        private const val PROJECT_NOT_FOUND_MSG = "존재하지 않는 프로젝트입니다."
+        private const val NOT_PROJECT_MEMBER_MSG = "프로젝트에 속한 회원이 아닙니다."
+        private const val MUST_HAVE_AT_LEAST_ONE_OWNER_MSG = "프로젝트에 최소 한 명 이상의 OWNER 권한이 존재해야 합니다."
+    }
+
+    fun edit(
+        projectRowid: Long,
+        targetMemberRowid: Long,
+        targetPermission: ProjectMemberPermission,
+        loginMemberRowid: Long,
+    ): Long = transaction {
+        memberRepository.findByIdOrNull(loginMemberRowid)
+            ?: throw BusinessException(MEMBER_NOT_FOUND_MSG)
+
+        val project = projectRepository.findByIdOrNull(projectRowid)
+            ?: throw BusinessException(PROJECT_NOT_FOUND_MSG)
+
+        val projectMembers = projectMemberRepository.findByProject(project)
+        val targetMember = projectMembers.find { it.member.rowid == targetMemberRowid }
+            ?: throw BusinessException(NOT_PROJECT_MEMBER_MSG)
+
+        if (targetMember.permission == targetPermission) {
+            return@transaction targetMember.rowid
+        }
+
+        checkIfLastOwner(projectMembers, targetMember, targetPermission)
+
+        targetMember.permission = targetPermission
+        projectMemberRepository.save(targetMember)
+
+        return@transaction targetMember.rowid
+    }
+
+    private fun checkIfLastOwner(
+        projectMembers: List<ProjectMember>,
+        targetMember: ProjectMember,
+        targetPermission: ProjectMemberPermission
+    ) {
+        val isTargetOwner = targetMember.permission == ProjectMemberPermission.OWNER
+        val isChangingFromOwner = isTargetOwner && targetPermission != ProjectMemberPermission.OWNER
+        val ownerCount = projectMembers.count { it.permission == ProjectMemberPermission.OWNER }
+
+        if (isChangingFromOwner && ownerCount == 1) {
+            throw BusinessException(MUST_HAVE_AT_LEAST_ONE_OWNER_MSG)
+        }
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/service/tag/ProductBacklogTagService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/tag/ProductBacklogTagService.kt
@@ -3,8 +3,7 @@ package com.project.scrumbleserver.service.tag
 import com.project.scrumbleserver.domain.productBacklog.ProductBacklog
 import com.project.scrumbleserver.domain.project.Project
 import com.project.scrumbleserver.domain.tag.ProductBacklogTag
-import com.project.scrumbleserver.domain.tag.Tag
-import com.project.scrumbleserver.global.excception.BusinessException
+import com.project.scrumbleserver.global.exception.BusinessException
 import com.project.scrumbleserver.repository.tag.ProductBacklogTagRepository
 import com.project.scrumbleserver.repository.tag.TagRepository
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/project/scrumbleserver/service/tag/TagService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/tag/TagService.kt
@@ -4,7 +4,7 @@ import com.project.scrumbleserver.api.tag.ApiGetAllProjectTagResponse
 import com.project.scrumbleserver.domain.project.Project
 import com.project.scrumbleserver.domain.tag.BasicTag
 import com.project.scrumbleserver.domain.tag.Tag
-import com.project.scrumbleserver.global.excception.BusinessException
+import com.project.scrumbleserver.global.exception.BusinessException
 import com.project.scrumbleserver.repository.project.ProjectRepository
 import com.project.scrumbleserver.repository.tag.TagRepository
 import org.springframework.data.repository.findByIdOrNull


### PR DESCRIPTION
## 📌 개요 (Summary)

프로젝트 생성 시 로그인한 회원을 ProjectMember에 넣는 로직이 빠져있어서 추가했습니다.

## ✨ 변경사항 (Changes)
- [ ] 주요 기능 구현
- [x] API 스펙 변경
- [ ] 버그 수정
- [ ] 테스트 코드 추가/수정
- 기타:

## 🧩 관련 이슈 (Related Issues)
- close #68  

## 🔍 주요 작업 내역 (What I Did)

- 기존 `ProductMemberPermission `의 이름을 `ProjectMemberPermission `로 수정했습니다.
- `ProjectMemberRepository`를 추가하여, 프로젝트를 생성한 회원을 주입하도록 추가했습니다.
- `Project`를 생성할 때, 하나의 트랜잭션에 묶어서 동작하도록 수정했습니다.

## ❗️리뷰 시 유의사항 (Notice for Reviewer)

꼼꼼한 리뷰 부탁드림돠~!