### PR TITLE
@RequestUserId 어노테이션이 붙은 api 에서 발생하는 500 에러를 수정한다.

### DIFF
--- a/src/main/kotlin/com/project/scrumbleserver/controller/handler/ApiControllerAdvice.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/handler/ApiControllerAdvice.kt
@@ -7,7 +7,9 @@ import com.project.scrumbleserver.global.exception.ServerException
 import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -17,33 +19,72 @@ private val logger = KotlinLogging.logger {}
 class ApiControllerAdvice {
 
     @ExceptionHandler(BusinessException::class)
-    fun exceptionHandler(e: BusinessException): ResponseEntity<ApiResponse<ErrorResponse>> {
+    fun exceptionHandler(
+        e: BusinessException,
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
         val errorResponse = ApiResponse.of(ErrorResponse(e.message), e.status)
         logger.warn(e.message)
         return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, e.status)
     }
 
     @ExceptionHandler(ServerException::class)
-    fun exceptionHandler(e: ServerException): ResponseEntity<ApiResponse<ErrorResponse>> {
+    fun exceptionHandler(
+        e: ServerException,
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
         val errorResponse = ApiResponse.of(ErrorResponse(e.message), HttpStatus.INTERNAL_SERVER_ERROR)
         logger.error(e.stackTraceToString())
-        return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR)
+        return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, errorResponse.status)
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationEx(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<*>> {
-        val errorMessages = ex.bindingResult.fieldErrors.associate {
+    fun exceptionHandler(
+        e: MethodArgumentNotValidException,
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
+        val errorMessages = e.bindingResult.fieldErrors.associate {
             it.field to (it.defaultMessage ?: "잘못된 값입니다.")
         }
+        logger.warn(e.message)
+        val errorResponse = ApiResponse.of(
+            ErrorResponse(errorMessages.toString()),
+            HttpStatus.BAD_REQUEST
+        )
 
-        return ResponseEntity
-            .badRequest()
-            .body(ApiResponse.of(errorMessages, HttpStatus.BAD_REQUEST))
+        return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, errorResponse.status)
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun exceptionHandler(
+        e: HttpMessageNotReadableException,
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
+        val errorResponse = ApiResponse.of(
+            ErrorResponse(e.message ?: "잘못된 요청 형식입니다."),
+            HttpStatus.BAD_REQUEST
+        )
+        logger.warn(e.message)
+        return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, errorResponse.status)
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun exceptionHandler(
+        e: MissingServletRequestParameterException,
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
+        val errorResponse = ApiResponse.of(
+            ErrorResponse(e.message ?: "필수 요청 파라미터가 누락되었습니다."),
+            HttpStatus.BAD_REQUEST
+        )
+        logger.warn(e.message)
+        return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, errorResponse.status)
     }
 
     @ExceptionHandler(Exception::class)
-    fun handleException(e: Exception): ResponseEntity<ApiResponse<ErrorResponse>> {
-        val errorResponse = ApiResponse.of(ErrorResponse("Internal Server Error"), HttpStatus.INTERNAL_SERVER_ERROR)
-        return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR)
+    fun exceptionHandler(
+        e: Exception,
+    ): ResponseEntity<ApiResponse<ErrorResponse>> {
+        val errorResponse = ApiResponse.of(
+            ErrorResponse("서버 내부에서 에러가 발생했습니다."),
+            HttpStatus.INTERNAL_SERVER_ERROR
+        )
+        logger.error(e.stackTraceToString())
+        return ResponseEntity<ApiResponse<ErrorResponse>>(errorResponse, errorResponse.status)
     }
 }

--- a/src/main/kotlin/com/project/scrumbleserver/domain/BaseEntity.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/BaseEntity.kt
@@ -15,6 +15,7 @@ abstract class BaseEntity {
     @Column(name = "reg_date", updatable = false)
     var regDate: LocalDateTime = LocalDateTime.now()
 
+    @Column(name = "is_deleted", nullable = false)
     private var isDeleted: Boolean = false
 
     fun delete() {


### PR DESCRIPTION
## 📌 개요 (Summary)
- 요청시 발생하는 500 에러를 수정한다.

## ✨ 변경사항 (Changes)
- [ ] 주요 기능 구현
- [ ] API 스펙 변경
- [X] 버그 수정
- [ ] 테스트 코드 추가/수정
- 기타:

## 🧩 관련 이슈 (Related Issues)
- resolve #85 

## 🔍 주요 작업 내역 (What I Did)
- 항목별로 정리해 주세요.
    - baseEntity 의 isDeleted 칼럼의 이름을 is_deleted로 수정하였습니다
    - ApiControllerAdvice 에 HttpMessageNotReadableException, MissingServletRequestParameterException에 대한 예외 케이스를 추가하였습니다.

## ❗️리뷰 시 유의사항 (Notice for Reviewer)
- 제가 테스트 해보기론 로그인이나 필터에서 에러는 없는 것 같고, 다른 부분에서 에러가 발생하고 있었는데 `@ExceptionHandler(Exception::class)` 의 에러 핸들러를 타서 어떤 에러인지 자세히 알 수 없었던 것 같습니다. 
- 우선 HttpMessageNotReadableException, MissingServletRequestParameterException 애 대한 에러 핸들러를 추가했고, 에러 발생 시 서버에 로그가 찍히도록 조치하였고, 이후에 추가로 에러가 발생하면 다시 한번 확인 하겠습니다 !
