### PR TITLE
role 을 멤버에서 프로젝트로 옮긴다

### DIFF
--- a/src/main/kotlin/com/project/scrumbleserver/api/projectMember/ApiPutUpdateRole.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/api/projectMember/ApiPutUpdateRole.kt
@@ -1,0 +1,19 @@
+package com.project.scrumbleserver.api.projectMember
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+const val API_PUT_UPDATE_ROLE_PATH = "/api/v1/project-member/update/role"
+
+data class ApiPutUpdateRoleRequest(
+    @field:NotNull(message = "projectRowid는 필수입니다.")
+    val projectRowid: Long,
+    @field:NotNull(message = "memberRowid는 필수입니다.")
+    val memberRowid: Long,
+    @field:NotBlank(message = "role은 필수입니다.")
+    val role: String,
+)
+
+data class ApiPutUpdateRoleResponse(
+    val projectMemberRowid: Long,
+)

--- a/src/main/kotlin/com/project/scrumbleserver/controller/projectMember/ProjectMemberController.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/controller/projectMember/ProjectMemberController.kt
@@ -2,10 +2,13 @@ package com.project.scrumbleserver.controller.projectMember
 
 import com.project.scrumbleserver.api.projectMember.API_GET_PROJECT_MEMBERS
 import com.project.scrumbleserver.api.projectMember.API_PUT_PROJECT_MEMBER_PERMISSION_PATH
+import com.project.scrumbleserver.api.projectMember.API_PUT_UPDATE_ROLE_PATH
 import com.project.scrumbleserver.api.projectMember.ApiGetProjectMembersRequest
 import com.project.scrumbleserver.api.projectMember.ApiGetProjectMembersResponse
 import com.project.scrumbleserver.api.projectMember.ApiPutProjectMemberPermissionRequest
 import com.project.scrumbleserver.api.projectMember.ApiPutProjectMemberPermissionResponse
+import com.project.scrumbleserver.api.projectMember.ApiPutUpdateRoleRequest
+import com.project.scrumbleserver.api.projectMember.ApiPutUpdateRoleResponse
 import com.project.scrumbleserver.domain.projectMember.ProjectMemberPermission
 import com.project.scrumbleserver.global.api.ApiResponse
 import com.project.scrumbleserver.security.RequestUserRowid
@@ -40,15 +43,33 @@ class ProjectMemberController(
         summary = "프로젝트 회원 권한 수정",
         description = "프로젝트에 속한 회원의 권한을 수정합니다.",
     )
-    fun edit(
+    fun editPermission(
         @RequestBody @Valid
         request: ApiPutProjectMemberPermissionRequest,
         @RequestUserRowid userRowid: Long,
     ): ApiResponse<ApiPutProjectMemberPermissionResponse> {
         projectMemberService.assertPermission(request.projectRowid, userRowid, ProjectMemberPermission.OWNER)
 
-        val projectMemberRowid = projectMemberService.edit(request.projectRowid, request.memberRowid, request.permission, userRowid)
+        val projectMemberRowid = projectMemberService.editPermission(request.projectRowid, request.memberRowid, request.permission, userRowid)
         val response = ApiPutProjectMemberPermissionResponse(projectMemberRowid)
+        return ApiResponse.of(response)
+    }
+
+    @PutMapping(API_PUT_UPDATE_ROLE_PATH)
+    @Operation(
+        summary = "프로젝트 회원 역할 수정",
+        description = "프로젝트에 속한 회원의 역할을 수정합니다.",
+    )
+    fun editRole(
+        @RequestBody @Valid
+        request: ApiPutUpdateRoleRequest,
+        @RequestUserRowid userRowid: Long,
+    ): ApiResponse<ApiPutUpdateRoleResponse> {
+        projectMemberService.assertPermission(request.projectRowid, userRowid, ProjectMemberPermission.CAN_EDIT)
+
+        val projectMemberRowid = projectMemberService.editRole(request.projectRowid, request.memberRowid, request.role)
+        val response = ApiPutUpdateRoleResponse(projectMemberRowid)
+
         return ApiResponse.of(response)
     }
 }

--- a/src/main/kotlin/com/project/scrumbleserver/domain/projectMember/ProjectMember.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/domain/projectMember/ProjectMember.kt
@@ -20,13 +20,24 @@ class ProjectMember(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "project_member_rowid")
     var rowid: Long = 0L,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_rowid", nullable = false)
     val project: Project,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_rowid", nullable = false)
     val member: Member,
+
+    @Column(nullable = false, length = 50)
+    var role: String = DEFAULT_ROLE,
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     var permission: ProjectMemberPermission = ProjectMemberPermission.CAN_VIEW,
-) : BaseEntity()
+) : BaseEntity() {
+
+    companion object {
+        const val DEFAULT_ROLE = "participant"
+    }
+}

--- a/src/main/kotlin/com/project/scrumbleserver/service/projectMember/ProjectMemberService.kt
+++ b/src/main/kotlin/com/project/scrumbleserver/service/projectMember/ProjectMemberService.kt
@@ -30,76 +30,66 @@ class ProjectMemberService(
         projectRowid: Long,
         memberRowid: Long,
         required: ProjectMemberPermission,
-    ) {
-        transaction.readOnly {
-            val member =
-                memberRepository.findByIdOrNull(memberRowid)
-                    ?: throw BusinessException(MEMBER_NOT_FOUND_MSG)
+    ) = transaction.readOnly {
+        val member = memberRepository.findByIdOrNull(memberRowid)
+            ?: throw BusinessException(MEMBER_NOT_FOUND_MSG)
 
-            val project =
-                projectRepository.findByIdOrNull(projectRowid)
-                    ?: throw BusinessException(PROJECT_NOT_FOUND_MSG)
+        val project = projectRepository.findByIdOrNull(projectRowid)
+            ?: throw BusinessException(PROJECT_NOT_FOUND_MSG)
 
-            val projectMember =
-                projectMemberRepository.findByProjectAndMember(project, member)
-                    ?: throw BusinessException(NOT_PROJECT_MEMBER_MSG)
+        val projectMember = projectMemberRepository.findByProjectAndMember(project, member)
+            ?: throw BusinessException(NOT_PROJECT_MEMBER_MSG)
 
-            if (!projectMember.permission.hasAtLeast(required)) {
-                throw BusinessException(INSUFFICIENT_PROJECT_PERMISSION_MSG)
-            }
+        if (!projectMember.permission.hasAtLeast(required)) {
+            throw BusinessException(INSUFFICIENT_PROJECT_PERMISSION_MSG)
         }
     }
 
-    fun findAllByProjectRowid(projectRowid: Long): ApiGetProjectMembersResponse =
-        transaction.readOnly {
-            val project =
-                projectRepository.findByIdOrNull(projectRowid)
-                    ?: throw BusinessException(PROJECT_NOT_FOUND_MSG)
+    fun findAllByProjectRowid(projectRowid: Long): ApiGetProjectMembersResponse = transaction.readOnly {
+        val project = projectRepository.findByIdOrNull(projectRowid)
+            ?: throw BusinessException(PROJECT_NOT_FOUND_MSG)
 
-            val projectMembers = projectMemberRepository.findByProject(project)
+        val projectMembers = projectMemberRepository.findByProject(project)
 
-            ApiGetProjectMembersResponse(
-                projectMembers.map { projectMember ->
-                    ApiGetProjectMembersResponse.Member(
-                        memberRowid = projectMember.member.rowid,
-                        email = projectMember.member.email,
-                        profileImageUrl = projectMember.member.profileImageUrl,
-                        permission = projectMember.permission.name,
-                    )
-                },
-            )
-        }
+        ApiGetProjectMembersResponse(
+            projectMembers.map { projectMember ->
+                ApiGetProjectMembersResponse.Member(
+                    memberRowid = projectMember.member.rowid,
+                    email = projectMember.member.email,
+                    profileImageUrl = projectMember.member.profileImageUrl,
+                    permission = projectMember.permission.name,
+                )
+            },
+        )
+    }
 
-    fun edit(
+    fun editPermission(
         projectRowid: Long,
         targetMemberRowid: Long,
         targetPermission: ProjectMemberPermission,
         loginMemberRowid: Long,
-    ): Long =
-        transaction {
-            memberRepository.findByIdOrNull(loginMemberRowid)
-                ?: throw BusinessException(MEMBER_NOT_FOUND_MSG)
+    ): Long = transaction {
+        memberRepository.findByIdOrNull(loginMemberRowid)
+            ?: throw BusinessException(MEMBER_NOT_FOUND_MSG)
 
-            val project =
-                projectRepository.findByIdOrNull(projectRowid)
-                    ?: throw BusinessException(PROJECT_NOT_FOUND_MSG)
+        val project = projectRepository.findByIdOrNull(projectRowid)
+            ?: throw BusinessException(PROJECT_NOT_FOUND_MSG)
 
-            val projectMembers = projectMemberRepository.findByProject(project)
-            val targetMember =
-                projectMembers.find { it.member.rowid == targetMemberRowid }
-                    ?: throw BusinessException(NOT_PROJECT_MEMBER_MSG)
+        val projectMembers = projectMemberRepository.findByProject(project)
+        val targetMember = projectMembers.find { it.member.rowid == targetMemberRowid }
+            ?: throw BusinessException(NOT_PROJECT_MEMBER_MSG)
 
-            if (targetMember.permission == targetPermission) {
-                return@transaction targetMember.rowid
-            }
-
-            checkIfLastOwner(projectMembers, targetMember, targetPermission)
-
-            targetMember.permission = targetPermission
-            projectMemberRepository.save(targetMember)
-
+        if (targetMember.permission == targetPermission) {
             return@transaction targetMember.rowid
         }
+
+        checkIfLastOwner(projectMembers, targetMember, targetPermission)
+
+        targetMember.permission = targetPermission
+        projectMemberRepository.save(targetMember)
+
+        return@transaction targetMember.rowid
+    }
 
     private fun checkIfLastOwner(
         projectMembers: List<ProjectMember>,
@@ -113,5 +103,22 @@ class ProjectMemberService(
         if (isChangingFromOwner && ownerCount == 1) {
             throw BusinessException(MUST_HAVE_AT_LEAST_ONE_OWNER_MSG)
         }
+    }
+
+    fun editRole(
+        projectRowid: Long,
+        memberRowid: Long,
+        role: String,
+    ) = transaction {
+        val project = projectRepository.findByIdOrNull(projectRowid)
+            ?: throw BusinessException(PROJECT_NOT_FOUND_MSG)
+        val member = memberRepository.findByIdOrNull(memberRowid)
+            ?: throw BusinessException(MEMBER_NOT_FOUND_MSG)
+
+        val projectMember = projectMemberRepository.findByProjectAndMember(project, member)
+            ?: throw BusinessException(NOT_PROJECT_MEMBER_MSG)
+        projectMember.role = role
+
+        return@transaction projectMember.rowid
     }
 }


### PR DESCRIPTION
## 📌 개요 (Summary)
- 기존 member 엔티티에 존재하던 role 필드를 project 엔티티로 옮겼습니다.

## ✨ 변경사항 (Changes)
- [X] 주요 기능 구현
- [X] API 스펙 변경
- [ ] 버그 수정
- [ ] 테스트 코드 추가/수정
- 기타:

## 🧩 관련 이슈 (Related Issues)
- close #89 

## 🔍 주요 작업 내역 (What I Did)
- ProjectMember
  - role 필드가 추가되었습니다.
  - 프로젝트 초대시 기본 role은 'participant' 입니다.
  - 프로젝트 초대 받은 이후 role을 수정할 수 있는 폼이 있어야 할 것 같습니다.
- ProjectMemberController 
  - 초대받은 프로젝트에서의 role을 수정할 수 있는 api를 추가하였습니다.

## ❗️리뷰 시 유의사항 (Notice for Reviewer)
- 린트를 시원하게 질렀는데 너무 맘에 안드네요 .... 작업 하시다가 맘에 안드시는 부분 있으면 편하게 수정 하셔도 좋을 것 같습니다~!
